### PR TITLE
Fix for incorrectly displayed float values

### DIFF
--- a/lib/HTMLWriter.py
+++ b/lib/HTMLWriter.py
@@ -1,5 +1,4 @@
 
-
 # from EpicsArchiver import  config
 # from EpicsArchiver.util import SEC_DAY
 
@@ -240,7 +239,7 @@ class HTMLWriter:
         istyped = False
         fmt="%s='%s'"
         if isinstance(v,(int,long)):      fmt,istyped = "%s=%i",True
-        elif isinstance(v,(float)):       fmt,istyped = "%s=%i",True
+        elif isinstance(v,(float)):       fmt,istyped = "%s=%f",True
         elif isinstance(v,(str,unicode)): fmt,istyped = "%s='%s'",True
         
         if not istyped: v = str(v)


### PR DESCRIPTION
Float values (eg, deadband) were always showing up as "0", even when I changed them to, eg, "0.005".

(PS: I didn't remove that newline at the top, github did.)
